### PR TITLE
fix: update firtool version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,15 @@ V_FILE_GEN   = build/ysyxSoCTop.sv
 V_FILE_FINAL = build/ysyxSoCFull.v
 SCALA_FILES = $(shell find src/ -name "*.scala")
 
+# Firtool version
+FIRTOOL_VERSION = 1.105.0
+FIRTOOL_PATCH_DIR = $(shell pwd)/patch/firtool
+
 $(V_FILE_FINAL): $(SCALA_FILES)
+# Replace firtool with a newer version
+# TODO: This can be removed after chisel publishes a new version
+	@./patch/update-firtool.sh $(FIRTOOL_VERSION) $(FIRTOOL_PATCH_DIR)
+	CHISEL_FIRTOOL_PATH=$(FIRTOOL_PATCH_DIR)/firtool-$(FIRTOOL_VERSION)/bin \
 	mill -i ysyxsoc.runMain ysyx.Elaborate --target-dir $(@D)
 	mv $(V_FILE_GEN) $@
 	sed -i -e 's/_\(aw\|ar\|w\|r\|b\)_\(\|bits_\)/_\1/g' $@

--- a/patch/update-firtool.sh
+++ b/patch/update-firtool.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -eu
+
+# Usage:
+#   replace_firtool <firtool_url> <firtool_sha256_url> <firtool_update_version>
+replace_firtool() {
+    local firtool_url=$1
+    local firtool_sha256_url=$2
+    local firtool_update_version=$3
+    local firtool_patch_dir=$4
+
+    # Check if firtool directory exists
+    if [ -d $firtool_patch_dir ]; then
+        echo "Found existing firtool directory in $firtool_patch_dir"
+        echo "If you want to update firtool, please remove the existing firtool directory"
+        exit 0
+    fi
+
+    # Create temporary directory
+    local firtool_temp=$(mktemp -d)
+    echo "Downloading firtool version $firtool_update_version from $firtool_url..."
+    curl -L -o $firtool_temp/firtool.tar.gz $firtool_url
+    echo "Downloading SHA256 checksum from $firtool_sha256_url..."
+    # Check SHA256 checksum
+    check_sha256=$(curl -L $firtool_sha256_url)
+    echo "Checking SHA256 checksum..."
+    echo "$check_sha256 $firtool_temp/firtool.tar.gz" | sha256sum -c -
+
+    if [ $? -ne 0 ]; then
+        echo "SHA256 checksum failed"
+        exit 1
+    fi
+
+    # Extract firtool to patch directory
+    mkdir -p $firtool_patch_dir
+    tar -xzf $firtool_temp/firtool.tar.gz -C $firtool_patch_dir
+    chmod +x $firtool_patch_dir/firtool-$firtool_update_version/bin/firtool
+}
+
+update_firtool() {
+    local firtool_update_version=$1
+    local firtool_patch_dir=$2
+
+    case "$(uname -s)" in
+        Linux*) firtool_arch="linux-x64";;
+        Darwin*)
+            if [ "$(uname -m)" == "arm64" ]; then
+                # CIRCT does not release darwin arm64 binary yet
+                # so we need to build it from source
+                echo "Unsupported darwin architecture"
+                echo "Please build firtool from source, see: https://github.com/llvm/circt?tab=readme-ov-file#setting-this-up"
+                echo "Then copy the built firtool binary to $firtool_patch_dir/firtool-$firtool_update_version/bin/firtool"
+                exit 1
+            else
+                firtool_arch="macos-x64"
+            fi
+            ;;
+        *) echo "Unsupported OS"; exit 1;;
+    esac
+
+    local firtool_url="https://github.com/llvm/circt/releases/download/firtool-${firtool_update_version}/firrtl-bin-${firtool_arch}.tar.gz"
+    local firtool_sha256="https://github.com/llvm/circt/releases/download/firtool-${firtool_update_version}/firrtl-bin-${firtool_arch}.tar.gz.sha256"
+
+    case "$(uname -s)" in
+        Linux*) replace_firtool $firtool_url $firtool_sha256 $firtool_update_version $firtool_patch_dir;;
+        Darwin*) replace_firtool $firtool_url $firtool_sha256 $firtool_update_version $firtool_patch_dir;;
+        *) echo "Unsupported OS"; exit 1;;
+    esac
+}
+
+# Call update_firtool with version and patch directory
+# e.g. update_firtool 1.105.0 `pwd`/patch/firtool
+update_firtool $1 $2


### PR DESCRIPTION
### Background
* Chisel 7.0.0-M2 was published against firtool version 1.77.0
* After replacing `sdram` with `sdramChisel` module in `SoC.scala`, firtool 1.77.0 reports a non-zero exit code and a crash backtrace

### Steps to Reproduce Bug
After replaced `sdram` with `sdramChisel` module in `SoC.scala`:
```diff
diff --git a/src/SoC.scala b/src/SoC.scala
--- a/src/SoC.scala
+++ b/src/SoC.scala
@@ -142,7 +142,7 @@ class ysyxSoCFull(implicit p: Parameters) extends LazyModule {

     val psram = Module(new psram)
     psram.io <> masic.psram
-    val sdram = Module(new sdram)
+    val sdram = Module(new sdramChisel)
     sdram.io <> masic.sdram

     val externalPins = IO(new Bundle{

```
Then generate the verilog:
```shell
make verilog
```
firtool 1.77.0 will report the following errors:
```shell
[309/309] ysyxsoc.runMain
[309] Exception in thread "main" circt.stage.phases.Exceptions$FirtoolNonZeroExitCode: /home/emin/.cache/llvm-firtool/1.77.0/bin/firtool returned a non-zero exit code. Note that this version of Chisel (7.0.0-M2) was published against firtool version 1.77.0.
[309] ------------------------------------------------------------------------------
[309] ExitCode:
[309] 139
[309] STDOUT:
[309]
[309] STDERR:
[309] PLEASE submit a bug report to https://github.com/llvm/circt and include the crash backtrace.
[309]  #0 0x00000000006b8e27 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0x6b8e27)
[309]  #1 0x00000000006b6bde llvm::sys::RunSignalHandlers() (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0x6b6bde)
[309]  #2 0x00000000006b974f SignalHandler(int) Signals.cpp:0:0
[309]  #3 0x00007f81a5302620 __restore_rt (/nix/store/wn7v2vhyyyi6clcyn0s9ixvl7d4d87ic-glibc-2.40-36/lib/libc.so.6+0x40620)
[309]  #4 0x0000000000b0aa50 mlir::detail::OperandStorage::OperandStorage(mlir::Operation*, mlir::OpOperand*, mlir::ValueRange) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0xb0aa50)
[309]  #5 0x0000000000afd97b mlir::Operation::create(mlir::Location, mlir::OperationName, mlir::TypeRange, mlir::ValueRange, mlir::DictionaryAttr, mlir::OpaqueProperties, mlir::BlockRange, unsigned int) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0xafd97b)
[309]  #6 0x0000000000afd417 mlir::Operation::create(mlir::Location, mlir::OperationName, mlir::TypeRange, mlir::ValueRange, mlir::NamedAttrList&&, mlir::OpaqueProperties, mlir::BlockRange, mlir::RegionRange) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0xafd417)
[309]  #7 0x0000000000afd2d4 mlir::Operation::create(mlir::OperationState const&) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0xafd2d4)
[309]  #8 0x0000000000a68210 mlir::OpBuilder::create(mlir::OperationState const&) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0xa68210)
[309]  #9 0x0000000000b75fa0 circt::hw::InstanceOp mlir::OpBuilder::create<circt::hw::InstanceOp, mlir::Operation*&, mlir::StringAttr, llvm::SmallVector<mlir::Value, 8u>&, mlir::ArrayAttr&, circt::hw::InnerSymAttr&>(mlir::Location, mlir::Operation*&, mlir::StringAttr&&, llvm::SmallVector<mlir::Value, 8u>&, mlir::ArrayAttr&, circt::hw::InnerSymAttr&) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0xb75fa0)
[309] #10 0x0000000000b72ae1 circt::firrtl::DeclVisitor<(anonymous namespace)::FIRRTLLowering, mlir::LogicalResult>::dispatchDeclVisitor(mlir::Operation*) LowerToHW.cpp:0:0
[309] #11 0x0000000000b4d482 _ZZN12_GLOBAL__N_120FIRRTLModuleLowering14runOnOperationEvENK3$_8clImEEDaT_ LowerToHW.cpp:0:0
[309] #12 0x0000000000b77689 std::_Function_handler<void (), mlir::LogicalResult mlir::failableParallelForEach<llvm::detail::SafeIntIterator<unsigned long, false>, (anonymous namespace)::FIRRTLModuleLowering::runOnOperation()::$_8>(mlir::MLIRContext*, llvm::detail::SafeIntIterator<unsigned long, false>, llvm::detail::SafeIntIterator<unsigned long, false>, (anonymous namespace)::FIRRTLModuleLowering::runOnOperation()::$_8&&)::'lambda'()>::_M_invoke(std::_Any_data const&) LowerToHW.cpp:0:0
[309] #13 0x000000000072bb58 std::_Function_handler<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> (), std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<std::function<void ()>>>, void>>::_M_invoke(std::_Any_data const&) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0x72bb58)
[309] #14 0x000000000072bab7 std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0x72bab7)
[309] #15 0x00007f81a5357e2f __pthread_once_slow (/nix/store/wn7v2vhyyyi6clcyn0s9ixvl7d4d87ic-glibc-2.40-36/lib/libc.so.6+0x95e2f)
[309] #16 0x000000000072be6b std::__future_base::_Deferred_state<std::thread::_Invoker<std::tuple<std::function<void ()>>>, void>::_M_complete_async() (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0x72be6b)
[309] #17 0x000000000072bee5 std::_Function_handler<void (), std::shared_future<void> llvm::ThreadPoolInterface::asyncImpl<void>(std::function<void ()>, llvm::ThreadPoolTaskGroup*)::'lambda'()>::_M_invoke(std::_Any_data const&) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0x72bee5)
[309] #18 0x00000000011ed74f llvm::StdThreadPool::processTasks(llvm::ThreadPoolTaskGroup*) (/home/emin/.cache/llvm-firtool/1.77.0/bin/firtool+0x11ed74f)
[309] #19 0x00000000011eeb8c void* llvm::thread::ThreadProxy<std::tuple<llvm::StdThreadPool::grow(int)::$_0>>(void*) ThreadPool.cpp:0:0
[309] #20 0x00007f81a5352d02 start_thread (/nix/store/wn7v2vhyyyi6clcyn0s9ixvl7d4d87ic-glibc-2.40-36/lib/libc.so.6+0x90d02)
[309] #21 0x00007f81a53d23ac __GI___clone3 (/nix/store/wn7v2vhyyyi6clcyn0s9ixvl7d4d87ic-glibc-2.40-36/lib/libc.so.6+0x1103ac)
[309]
[309] ------------------------------------------------------------------------------
[309/309] ============================== ysyxsoc.runMain ysyx.Elaborate --target-dir build ============================== 2s
1 tasks failed
ysyxsoc.runMain Subprocess failed
make: *** [Makefile:14: build/ysyxSoCFull.v] Error 1
```

### Solution

A newer version of firtool can slove this problem, but since chisel uses [firtool-resolver](https://github.com/chipsalliance/firtool-resolver/) to get firtool, we can't use it by adding firtool to the path, so we need to set the `CHISEL_FIRTOOL_PATH` environment variable to specify its path.

This PR is a temporary workaround until Chisel publishes a new version that includes the updated firtool.

The changes include:

1. Add a new script `patch/update-firtool.sh` that downloads the latest firtool version, verifies the SHA256 checksum, and extracts it to the `patch/firtool` directory.
2. Update the Makefile to call the `update-firtool.sh` script before running the `mill` command to generate the Verilog file.

This has been tested on the following platforms:

* NixOS 24.11
* macOS Sequoia 15.2